### PR TITLE
Release v5.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## v5.5.0
+**New Features**
+- Initial support for HEVC mode cameras\
+  Ring is actively enabling the H.265/HEVC codec on some newer camera models and the Ring Andriod-app based API used by ring-mqtt actively rejects any other protocol for these cameras.  The Ring web based dashboard uses a different API which appears to support negotiating H.264/AVC with these devices as a fallback but, so far, I haven't been able to get it to work correctly with ring-mqtt, hopefully that will be resolved eventually.
+
+  Passing HEVC through unchanged presents too many compatibility issues with downstream devices to be practical so, for now, ring-mqtt will attempt to transcode these streams back to H.264/AVC on-the-fly.  This provides wide compatibiltiy with downstream devices, but at the cost of significantly increased CPU usage during streaming.
+
+  Ideally, over time, more browsers will add H.265/HEVC support to their WebRTC implementations so passthrough will become a viable option, but, for now, transcoding provides a quick and dirty hack that will at least allow these cameras work in many cases.  Note that if you are running on a RPi3 this will probably not work, and an RPi4 will barely be able to support a single stream.
+- Add switch to toggle motion warning for cameras that support this feature
+- Implement new logic for entry/exit delay (inspired by @amura11):
+  - Exit delay now supports both home and away modes
+  - Depends on actual events from Ring API vs previous blind wait function
+  - Alarm attributes now include "exitSecondsLeft" and "entrySecondsLeft" which will count down during entry/exit delay.
+  - Alarm attributes now include "targetMode" so it's possible to know what mode alarm is attempting to enter even while exit delay is in progress.  For entry delay this attribute makes it possoble to know what mode the alarm was in when the entry delay was triggered.  This allows creating different automations for entry/exit delays based on the home and away arming modes.
+
+**Bugs Fixed**
+- Fix an issue detecting subscriptions and suppress spurrious error messages from cameras in case of accounts with no paid subscription.
+- Request non-cached snapshots for motion events on high-powered cameras even if no UUID is available (e.g. no subscription).
+- Make stream source and still image URL attributes work even if calls to heath check API fail.
+
+**Dependency Updates**
+- go2rtc v1.6.0
+- werift v0.18.4
+
 ## v5.4.1
 **Bugs Fixed**
 - Fix alarm state not updating for various conditions (armed/disarmed with keypad, exit-delay, etc)
@@ -102,16 +126,16 @@ If you have cameras/doorbells/intercoms and are not receiving notifications you 
 - Bump s6-overlay to v3.1.3.0
 
 ## v5.1.2 (re-publish of v5.1.1)
-**Fixed Bugs**  
+**Fixed Bugs**
 - Fix crash on Chime Pro (1st Generation) models
 
 ## v5.1.0
 After several releases focused on stability and minor bug fixes this release includes significant internal changes and a few new features.
 
-**!!!!! WARNING !!!!!**  
+**!!!!! WARNING !!!!!**
 Starting with 5.1.x all backwards compatibiltiy with prior 4.x style configuration options has been removed.  Upgrades from 4.x versions are still possible but will require manual conversion of any legacy configuration methods and options.  Upgrades from 5.0.x versions should not require any changes.
 
-**New Features**  
+**New Features**
 - Added ability to refine event stream to only motion events where a person is detected
 - Option to select transcoded vs raw video for event stream (this also changes the URL for scripting automatic download of recordings):
   - Raw video (default) - This video is exactly as it was recorded by the camera and is the same as previous versions of ring-mqtt
@@ -120,13 +144,13 @@ Starting with 5.1.x all backwards compatibiltiy with prior 4.x style configurati
 - Improved support for cameras with dual batteries.  The BatteryLevel attribute always reports the level of currently active battery but the level of both batteries is individually available via the batteryLife and batteryLife2 attributes.
 - Switch to enable/disable the Chime Pro nightlight.  The current nightlight on/off state can be determined via attribute.
 
-**Other Changes**  
+**Other Changes**
 - Reduced average live stream startup time by several hundred milliseconds with the following changes:
   - Switched from rtsp-simple-server to go2rtc as the core streaming engine which provides slightly faster stream startup and opens the door for future feature enhancements.  This switch is expected to be transparent for users, but please report any issues.
   - Cameras now allocate a dedicated worker thread for live streaming vs previous versions which used a pool of worker threads based on the number of processor cores detected.  This simplifies the live stream code and leads to faster stream startup and, hopefully, more reliable recovery from various error conditions.
   - The recommended configuration for streaming setup in Home Assistant is now to use the go2rtc addon with RTSPtoWebRTC integration.  This provides fast stream startup and shutdown and low-latency live vieweing (typically <1 second latency).
 
-**Dependency Updates**  
+**Dependency Updates**
 - Replaced problematic colors package with chalk for colorizing debug log output
 - Bump ring-client-api to 11.7.1 (various fixes and support for newer cameras)
 - Bump other dependent packages to latest versions

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: Ring-MQTT with Video Streaming
-version: 5.4.1
+version: 5.5.0
 slug: ring_mqtt
 description: Integrate Ring Devices into Home Assistant via MQTT and RTSP
 startup: application
@@ -48,5 +48,5 @@ schema:
   enable_panic: bool
   branch: str
   debug: str
-  location_ids: 
+  location_ids:
     - str


### PR DESCRIPTION
## v5.5.0
**New Features**
- Initial support for HEVC mode cameras\
  Ring is actively enabling the H.265/HEVC codec on some newer camera models and the Ring Andriod-app based API used by ring-mqtt actively rejects any other protocol for these cameras.  The Ring web based dashboard uses a different API which appears to support negotiating H.264/AVC with these devices as a fallback but, so far, I haven't been able to get it to work correctly with ring-mqtt, hopefully that will be resolved eventually.

  Passing HEVC through unchanged presents too many compatibility issues with downstream devices to be practical so, for now, ring-mqtt will attempt to transcode these streams back to H.264/AVC on-the-fly.  This provides wide compatibiltiy with downstream devices, but at the cost of significantly increased CPU usage during streaming.

  Ideally, over time, more browsers will add H.265/HEVC support to their WebRTC implementations so passthrough will become a viable option, but, for now, transcoding provides a quick and dirty hack that will at least allow these cameras work in many cases.  Note that if you are running on a RPi3 this will probably not work, and an RPi4 will barely be able to support a single stream.
- Add switch to toggle motion warning for cameras that support this feature
- Implement new logic for entry/exit delay (inspired by @amura11):
  - Exit delay now supports both home and away modes
  - Depends on actual events from Ring API vs previous blind wait function
  - Alarm attributes now include "exitSecondsLeft" and "entrySecondsLeft" which will count down during entry/exit delay.
  - Alarm attributes now include "targetMode" so it's possible to know what mode alarm is attempting to enter even while exit delay is in progress.  For entry delay this attribute makes it possoble to know what mode the alarm was in when the entry delay was triggered.  This allows creating different automations for entry/exit delays based on the home and away arming modes.

**Bugs Fixed**
- Fix an issue detecting subscriptions and suppress spurrious error messages from cameras in case of accounts with no paid subscription.
- Request non-cached snapshots for motion events on high-powered cameras even if no UUID is available (e.g. no subscription).
- Make stream source and still image URL attributes work even if calls to heath check API fail.

**Dependency Updates**
- go2rtc v1.6.0
- werift v0.18.4
