### PR TITLE
Release v5.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v5.5.1
+**New Features**
+- Improved support for HEVC mode cameras\
+  While the initial support for HEVC required local transcoding, this update uses a different streaming API that is able to negotiates down to H.264/AVC for these cameras on-the-fly which means HEVC enabled cameras should now work fine even on lower-performance hardware like RPi3/4 devices.  Hopefully this new API does not break streaming for other cases.
+
+**Other Changes**
+- Use a non-cached snapshot for all cases
+- Implement multiple retries if initial request for snapshot update fails
+
+**Dependency Updates**
+- go2rtc v1.6.2
+
 ## v5.5.0
 **New Features**
 - Initial support for HEVC mode cameras\

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: Ring-MQTT with Video Streaming
-version: 5.5.0
+version: 5.5.1
 slug: ring_mqtt
 description: Integrate Ring Devices into Home Assistant via MQTT and RTSP
 startup: application


### PR DESCRIPTION
## v5.5.1
**New Features**
- Improved support for HEVC mode cameras\
  While the initial support for HEVC required local transcoding, this update uses a different streaming API that is able to negotiates down to H.264/AVC for these cameras on-the-fly which means HEVC enabled cameras should now work fine even on lower-performance hardware like RPi3/4 devices.  Hopefully this new API does not break streaming for other cases.

**Other Changes**
- Use a non-cached snapshot for all cases
- Implement multiple retries if initial request for snapshot update fails

**Dependency Updates**
- go2rtc v1.6.2
