### PR TITLE
Release v5.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v5.6.5
+This release is intended to address the current brokenness of HA 2024.6.x by forcing the alarm control panel entity discovery to set code_arm_required = false even when no code is configured.  While I believe this should be fixed in upstream HA, I have no influence over if/when that will happen and this workaround should have no negative impact on older versions.
+
+**Dependency Updates**
+- go2rtc v1.9.3
+- mqtt v5.7.0
+- werift v0.19.3
+
 ## v5.6.4
 **Minor Enhancements**
 - New attributes alarmClearedBy/alarmClearedTime are updated when alarm is in triggered state and is cleared via the keypad or app.

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: Ring-MQTT with Video Streaming
-version: 5.6.4
+version: 5.6.5
 slug: ring_mqtt
 description: Integrate Ring Devices into Home Assistant via MQTT and RTSP
 startup: application


### PR DESCRIPTION
## v5.6.5
This release is intended to address the current brokenness of HA 2024.6.x by forcing the alarm control panel entity discovery to set code_arm_required = false even when no code is configured.  While I believe this should be fixed in upstream HA, I have no influence over if/when that will happen and this workaround should have no negative impact on older versions.

**Dependency Updates**
- go2rtc v1.9.3
- mqtt v5.7.0
- werift v0.19.3